### PR TITLE
Tweaks to api endpoints

### DIFF
--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -233,7 +233,7 @@ class MoloFormPage(
     ]
 
     api_fields = ["live", "form_fields", "introduction", "image",
-                  "thank_you_text"]
+                  "thank_you_text", "allow_anonymous_submissions"]
 
     def get_effective_extra_style_hints(self):
         return self.extra_style_hints

--- a/molo/forms/serializers.py
+++ b/molo/forms/serializers.py
@@ -30,7 +30,8 @@ class FormFieldSerializer(serializers.Field):
                     "default_value": item.default_value,
                     "help_text": item.help_text, "page_break": item.page_break,
                     "admin_label": item.admin_label, "choices": item.choices,
-                    "field_type": item.field_type})
+                    "field_type": item.field_type,
+                    "input_name": item.clean_name})
             return OrderedDict([
                 ("items", items),
             ])

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1442,6 +1442,8 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(form_fields[0]["choices"], self.form_field_1.choices)
         self.assertEqual(form_fields[0]["field_type"],
                          self.form_field_1.field_type)
+        self.assertEqual(form_fields[0]["input_name"],
+                         self.form_field_1.clean_name)
 
         self.assertEqual(form_fields[1]["sort_order"],
                          self.form_field_2.sort_order)
@@ -1452,6 +1454,8 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(form_fields[1]["choices"], self.form_field_2.choices)
         self.assertEqual(form_fields[1]["field_type"],
                          self.form_field_2.field_type)
+        self.assertEqual(form_fields[1]["input_name"],
+                         self.form_field_2.clean_name)
 
         self.assertEqual(form_fields[2]["sort_order"],
                          self.form_field_3.sort_order)
@@ -1462,14 +1466,13 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(form_fields[2]["choices"], self.form_field_3.choices)
         self.assertEqual(form_fields[2]["field_type"],
                          self.form_field_3.field_type)
+        self.assertEqual(form_fields[2]["input_name"],
+                         self.form_field_3.clean_name)
 
     def test_submit_form_endpoint_creates_a_submission(self):
-        field_1_label = self.form_field_1.label.lower().replace(' ', '-')
-        field_2_label = self.form_field_2.label.lower().replace(' ', '-')
-        field_3_label = self.form_field_3.label.lower().replace(' ', '-')
-
-        data = {field_1_label: "Tom", field_2_label: "cat",
-                field_3_label: "Yellow"}
+        data = {self.form_field_1.clean_name: "Tom",
+                self.form_field_2.clean_name: "cat",
+                self.form_field_3.clean_name: "Yellow"}
         response = self.client.post(
             '/api/v2/forms/%s/submit_form/' % self.molo_form_page.id,
             data,
@@ -1483,12 +1486,10 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(form_data, data)
 
     def test_submit_form_endpoint_returns_400_for_invalid_data(self):
-        field_1_label = self.form_field_1.label.lower().replace(' ', '-')
-        field_2_label = self.form_field_2.label.lower().replace(' ', '-')
-        field_3_label = self.form_field_3.label.lower().replace(' ', '-')
+        data = {self.form_field_1.clean_name: "Tom",
+                self.form_field_2.clean_name: "cat",
+                self.form_field_3.clean_name: "Copper"}
 
-        data = {field_1_label: "Tom", field_2_label: "cat",
-                field_3_label: "Copper"}
         response = self.client.post(
             '/api/v2/forms/%s/submit_form/' % self.molo_form_page.id,
             data,

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1395,6 +1395,18 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(obj["items"][0]["id"], self.molo_form_page.id)
         self.assertEqual(obj["items"][0]["title"], self.molo_form_page.title)
 
+    def test_list_endpoint_can_filter_by_allowing_anonymous_submissions(self):
+        self.another_molo_form_page.allow_anonymous_submissions = False
+        self.another_molo_form_page.save()
+        response = self.client.get(
+            '/api/v2/forms/?allow_anonymous_submissions=true')
+
+        obj = response.json()
+        self.assertIn("meta", obj)
+        self.assertEqual(obj["meta"]["total_count"], 1)
+        self.assertEqual(obj["items"][0]["id"], self.molo_form_page.id)
+        self.assertEqual(obj["items"][0]["title"], self.molo_form_page.title)
+
     def test_api_list_endpoint_excludes_personalisable_forms(self):
         personalisable_form = PersonalisableForm(title='Test Form')
         FormsIndexPage.objects.first().add_child(

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1499,3 +1499,20 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(response.status_code, 400)
         submissions = self.molo_form_page.get_submission_class().objects.all()
         self.assertEqual(len(submissions), 0)
+
+    def test_submit_form_endpoint_returns_400_for_unpublished_form(self):
+        self.molo_form_page.live = False
+        self.molo_form_page.save()
+        data = {self.form_field_1.clean_name: "Tom",
+                self.form_field_2.clean_name: "cat",
+                self.form_field_3.clean_name: "Yellow"}
+
+        response = self.client.post(
+            '/api/v2/forms/%s/submit_form/' % self.molo_form_page.id,
+            data,
+            format="json",
+            content_type="application/json")
+
+        self.assertEqual(response.status_code, 400)
+        submissions = self.molo_form_page.get_submission_class().objects.all()
+        self.assertEqual(len(submissions), 0)

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1395,6 +1395,23 @@ class TestAPIEndpointsView(TestCase, MoloTestCaseMixin):
         self.assertEqual(obj["items"][0]["id"], self.molo_form_page.id)
         self.assertEqual(obj["items"][0]["title"], self.molo_form_page.title)
 
+    def test_api_list_endpoint_excludes_personalisable_forms(self):
+        personalisable_form = PersonalisableForm(title='Test Form')
+        FormsIndexPage.objects.first().add_child(
+            instance=personalisable_form
+        )
+        personalisable_form.save_revision()
+        response = self.client.get('/api/v2/forms/')
+
+        obj = response.json()
+        self.assertIn("meta", obj)
+        self.assertEqual(obj["meta"]["total_count"], 2)
+        self.assertEqual(obj["items"][0]["id"], self.molo_form_page.id)
+        self.assertEqual(obj["items"][0]["title"], self.molo_form_page.title)
+        self.assertEqual(obj["items"][1]["id"], self.another_molo_form_page.id)
+        self.assertEqual(obj["items"][1]["title"],
+                         self.another_molo_form_page.title)
+
     def test_api_detail_endpoint(self):
         response = self.client.get(
             '/api/v2/forms/%s/' % self.molo_form_page.id)

--- a/molo/forms/views.py
+++ b/molo/forms/views.py
@@ -267,7 +267,7 @@ class MoloFormsEndpoint(PagesAPIEndpoint):
         instance = self.get_object()
         if not instance.live:
             raise ValidationError(
-                detail="Submissions to unpublished forms are not allowed.")
+                detail=_("Submissions to unpublished forms are not allowed."))
         builder = FormBuilder(instance.form_fields.all())
 
         # Populate the form with the submitted data

--- a/molo/forms/views.py
+++ b/molo/forms/views.py
@@ -8,7 +8,7 @@ from wagtail.core.models import Page
 
 from django.conf.urls import url
 from django.views.generic import TemplateView, View
-from molo.forms.models import MoloFormPage, FormsIndexPage
+from molo.forms.models import MoloFormPage, FormsIndexPage, PersonalisableForm
 from molo.core.models import ArticlePage
 from django.shortcuts import get_object_or_404, redirect
 
@@ -251,6 +251,9 @@ class MoloFormsEndpoint(PagesAPIEndpoint):
         This is overwritten in order to only show Forms
         '''
         queryset = MoloFormPage.objects.public()
+        # exclude PersonalisableForms and ones that require login
+        queryset = queryset.exclude(
+            id__in=PersonalisableForm.objects.public())
         request = self.request
 
         # Filter by site

--- a/molo/forms/views.py
+++ b/molo/forms/views.py
@@ -265,6 +265,9 @@ class MoloFormsEndpoint(PagesAPIEndpoint):
     def submit_form(self, request, pk):
         # Get the form
         instance = self.get_object()
+        if not instance.live:
+            raise ValidationError(
+                detail="Submissions to unpublished forms are not allowed.")
         builder = FormBuilder(instance.form_fields.all())
 
         # Populate the form with the submitted data


### PR DESCRIPTION
This PR contains a number of minor changes to the Form api endpoints.
Each commit contains the change and it's tests so it would probably be easiest to review each commit separately.

The first causes the list endpoint to only return MoloFormPages and exclude the PersonaisableForms subclass.
The second allows the list endpoint to filter forms based on if they allow anonymous submissions or not.
The third adds the clean_name attribute to the information sent for a field in the detail view. This attribute is used as the key for the field when submitting user answers.
The forth prevents submissions to forms that are not live.