### PR TITLE
hidden and multi-select form fields is not currently supported on molo

### DIFF
--- a/molo/forms/forms.py
+++ b/molo/forms/forms.py
@@ -140,6 +140,10 @@ class FormsFormBuilder(FormBuilder):
     def create_checkbox_field(self, field, options):
         return django.forms.BooleanField(**options)
 
+    def create_hidden_field(self, field, options):
+        return django.forms.CharField(
+            **options, widget=django.forms.HiddenInput)
+
     FIELD_TYPES = {
         'singleline': create_singleline_field,
         'multiline': create_multiline_field,
@@ -153,6 +157,7 @@ class FormsFormBuilder(FormBuilder):
         'radio': create_radio_field,
         'checkboxes': create_checkboxes_field,
         'checkbox': create_checkbox_field,
+        'hidden': create_hidden_field,
     }
 
     @property

--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -614,7 +614,7 @@ class MoloFormField(SkipLogicMixin, AdminLabelMixin,
         max_length=16,
         choices=[
             x for x in FORM_FIELD_CHOICES
-            if x[0] not in ['multiselect', 'hidden']
+            if x[0] != 'multiselect'
         ]
     )
     page = ParentalKey(MoloFormPage, related_name='form_fields')
@@ -770,7 +770,7 @@ class PersonalisableFormField(SkipLogicMixin, AdminLabelMixin,
         max_length=16,
         choices=[
             x for x in FORM_FIELD_CHOICES
-            if x[0] not in ['multiselect', 'hidden']
+            if x[0] != 'multiselect'
         ]
     )
     page = ParentalKey(PersonalisableForm, on_delete=models.CASCADE,

--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -612,7 +612,10 @@ class MoloFormField(SkipLogicMixin, AdminLabelMixin,
     field_type = models.CharField(
         verbose_name=_('field type'),
         max_length=16,
-        choices=[x for x in FORM_FIELD_CHOICES if x[0] != 'multiselect']
+        choices=[
+            x for x in FORM_FIELD_CHOICES
+            if x[0] not in ['multiselect', 'hidden']
+        ]
     )
     page = ParentalKey(MoloFormPage, related_name='form_fields')
 
@@ -764,7 +767,12 @@ class PersonalisableFormField(SkipLogicMixin, AdminLabelMixin,
     """
     field_type = models.CharField(
         verbose_name=_('field type'),
-        max_length=16, choices=FORM_FIELD_CHOICES)
+        max_length=16,
+        choices=[
+            x for x in FORM_FIELD_CHOICES
+            if x[0] not in ['multiselect', 'hidden']
+        ]
+    )
     page = ParentalKey(PersonalisableForm, on_delete=models.CASCADE,
                        related_name='personalisable_form_fields')
     segment = models.ForeignKey(

--- a/molo/forms/templates/forms/molo_form_page.html
+++ b/molo/forms/templates/forms/molo_form_page.html
@@ -16,29 +16,33 @@
         {% csrf_token %}
         {{ form.media }}
         {% for field in form %}
-          {% if fields_step %}
-            <h4 class="forms__question-title">
-              Question {{ fields_step.paginator.answered|length|add:forloop.counter }}
-            </h4>
+          {% if field.is_hidden %}
+            {{ field.as_hidden }}
           {% else %}
-            <h4 class="forms__question-title">
-              Question {{ forloop.counter }}
-            </h4>
-          {% endif %}
-          <fieldset>
-              <div class="input-group">
-                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                <span class="forms__helptext">{{ field.help_text }}</span>
-                {{ field }}
-                {% if field.errors %}
-                  <ul class="error error--forms">
-                  {% for error in field.errors %}
-                    <li>{{ error }}</li>
-                  {% endfor %}
-                  </ul>
-                {% endif %}
-              </div>
-          </fieldset>
+            {% if fields_step %}
+              <h4 class="forms__question-title">
+                Question {{ fields_step.paginator.answered|length|add:forloop.counter }}
+              </h4>
+            {% else %}
+              <h4 class="forms__question-title">
+                Question {{ forloop.counter }}
+              </h4>
+            {% endif %}
+            <fieldset>
+                <div class="input-group">
+                  <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+                  <span class="forms__helptext">{{ field.help_text }}</span>
+                  {{ field }}
+                  {% if field.errors %}
+                    <ul class="error error--forms">
+                    {% for error in field.errors %}
+                      <li>{{ error }}</li>
+                    {% endfor %}
+                    </ul>
+                  {% endif %}
+                </div>
+            </fieldset>
+        {% endif %}
         {% endfor %}
         {% trans "Submit Form" as text %}
         <input type="submit" value="{% if is_intermediate_step %}{% trans 'Next Question' %}{% else %}{{self.submit_text|default:text }}{% endif %}" />

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -697,6 +697,23 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
         self.assertNotContains(response,
                                'You have already completed this form.')
 
+    def test_hidden_form_field(self):
+        self.client.force_login(self.user)
+        form = create_molo_form_page(
+            self.forms_index, display_form_directly=True)
+        hidden_field = create_molo_form_formfield(
+            form, 'hidden', 'some hidden field')
+        req = RequestFactory()
+        req.user = self.user
+        req.site = self.site
+        response = self.client.get(form.url, request=req)
+        self.assertNotContains(response, hidden_field.label)
+        self.assertContains(
+            response,
+            '<input type="hidden" name="some-hidden-field" '
+            'id="id_some-hidden-field">'
+        )
+
 
 class TestDeleteButtonRemoved(TestCase, MoloTestCaseMixin):
 


### PR DESCRIPTION
Remove 'multiselect' and add support for 'hidden' FormFields as valid options for Molo field type