### PR TITLE
Feature/submission article page

### DIFF
--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -262,11 +262,29 @@ class MoloFormPage(
 
     def process_form_submission(self, form):
         user = form.user if not form.user.is_anonymous else None
-
+        article_page = form.cleaned_data.pop('article_page', None)
+        try:
+            article_page = int(article_page)
+        except Exception:
+            article_page = None
         self.get_submission_class().objects.create(
+            article_page_id=article_page,
             form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
             page=self, user=user
         )
+
+    def get_form_fields(self):
+        class MyQSList(list):
+            """trying to chain qs"""
+            def count(self):
+                return len(self)
+
+        fields = MyQSList(super().get_form_fields())
+        field = MoloFormField(
+            label='article_page',
+            field_type='hidden', required=False)
+        fields.append(field)
+        return fields
 
     def has_user_submitted_form(self, request, form_page_id):
         if 'completed_forms' not in request.session:

--- a/molo/forms/templates/forms/forms_list.html
+++ b/molo/forms/templates/forms/forms_list.html
@@ -35,6 +35,7 @@
 					          </fieldset>
 					        {% endfor %}
 									{% trans "Submit Form" as text %}
+					        <input type="hidden" name="article_page" value="{{ self.pk }}" />
 					        <input type="submit" value="{% if is_intermediate_step %}{% trans 'Next Question' %}{% else %}{{ form.submit_text|default:text }}{% endif %}" />
 					      </form>
 					    {% else %}

--- a/molo/forms/templates/forms/molo_form_page.html
+++ b/molo/forms/templates/forms/molo_form_page.html
@@ -45,6 +45,7 @@
         {% endif %}
         {% endfor %}
         {% trans "Submit Form" as text %}
+        <input type="hidden" name="article_page" value="{{ self.pk }}" />
         <input type="submit" value="{% if is_intermediate_step %}{% trans 'Next Question' %}{% else %}{{self.submit_text|default:text }}{% endif %}" />
 
       </form>

--- a/molo/forms/tests/test_utils.py
+++ b/molo/forms/tests/test_utils.py
@@ -76,8 +76,12 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
     def test_first_page_correct(self):
         page = self.paginator.page(1)
         self.assertEqual(
-            page.object_list,
-            [self.first_field, self.second_field],
+            page.object_list, [
+                self.hidden_field,
+                page.object_list[1],
+                self.first_field,
+                self.second_field
+            ],
         )
         self.assertTrue(page.has_next())
 
@@ -137,7 +141,11 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         self.assertEqual(previous_page_number, 1)
         self.assertEqual(
             paginator.page(previous_page_number).object_list,
-            [self.first_field, self.second_field],
+            [
+                self.hidden_field,
+                paginator.page(previous_page_number).object_list[1],
+                self.first_field,
+                self.second_field],
         )
 
     def test_question_progression_index(self):
@@ -341,8 +349,11 @@ class SkipLogicPaginatorMulti(TestCase, MoloTestCaseMixin):
 
     def test_first_page_correct(self):
         self.assertEqual(
-            self.paginator.page(1).object_list,
-            [self.first_field],
+            self.paginator.page(1).object_list, [
+                self.hidden_field,
+                self.paginator.page(1).object_list[1],
+                self.first_field
+            ],
         )
 
     def test_middle_page_correct(self):
@@ -407,8 +418,11 @@ class SkipLogicPaginatorPageBreak(TestCase, MoloTestCaseMixin):
 
     def test_first_page_correct(self):
         self.assertEqual(
-            self.paginator.page(1).object_list,
-            [self.first_field],
+            self.paginator.page(1).object_list, [
+                self.hidden_field,
+                self.paginator.page(1).object_list[1],
+                self.first_field
+            ],
         )
 
     def test_middle_page_correct(self):

--- a/molo/forms/tests/test_utils.py
+++ b/molo/forms/tests/test_utils.py
@@ -57,6 +57,14 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
             ),
             required=True
         )
+        self.hidden_field = MoloFormField.objects.create(
+            page=self.form,
+            sort_order=5,
+            default_value='cat',
+            label='Your least favourite animal',
+            field_type='hidden',
+            required=True
+        )
         self.paginator = SkipLogicPaginator(self.form.get_form_fields())
 
     def test_correct_num_pages(self):
@@ -237,6 +245,14 @@ class TestSkipLogicEveryPage(TestCase, MoloTestCaseMixin):
             ),
             required=True
         )
+        self.hidden_field = MoloFormField.objects.create(
+            page=self.form,
+            sort_order=5,
+            default_value='cat',
+            label='Your least favourite animal',
+            field_type='hidden',
+            required=True
+        )
         self.paginator = SkipLogicPaginator(self.form.get_form_fields())
 
     def test_initialises_correctly(self):
@@ -307,6 +323,14 @@ class SkipLogicPaginatorMulti(TestCase, MoloTestCaseMixin):
             field_type='singleline',
             required=True
         )
+        self.hidden_field = MoloFormField.objects.create(
+            page=self.form,
+            sort_order=5,
+            default_value='cat',
+            label='Your least favourite animal',
+            field_type='hidden',
+            required=True
+        )
         self.paginator = SkipLogicPaginator(self.form.get_form_fields())
 
     def test_correct_num_pages(self):
@@ -363,6 +387,14 @@ class SkipLogicPaginatorPageBreak(TestCase, MoloTestCaseMixin):
             sort_order=3,
             label='Your least favourite animal',
             field_type='singleline',
+            required=True
+        )
+        self.hidden_field = MoloFormField.objects.create(
+            page=self.form,
+            sort_order=5,
+            default_value='cat',
+            label='Your least favourite animal',
+            field_type='hidden',
             required=True
         )
         self.paginator = SkipLogicPaginator(self.form.get_form_fields())

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -79,7 +79,8 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
 
     def create_molo_form_page_with_field(
         self, parent, display_form_directly=False,
-        allow_anonymous_submissions=False, **kwargs):
+        allow_anonymous_submissions=False, **kwargs
+    ):
         molo_form_page = create_molo_form_page(
             parent,
             display_form_directly=display_form_directly,

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -730,6 +730,8 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
             allow_anonymous_submissions=True,
         )
         field = create_molo_form_formfield(form, 'singleline')
+        hidden_field = create_molo_form_formfield(
+            form, 'hidden', label="hidden_field lets check it out")
         ArticlePageForms.objects.create(page=self.article, form=form)
 
         url = self.article.get_full_url()
@@ -741,6 +743,7 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
         self.assertEqual(res.status_code, 200)
         self.assertIn(bytes(field.label, encoding='utf-8'), res.content)
         self.assertIn(bytes(article_field, encoding='utf-8'), res.content)
+        self.assertIn(bytes(hidden_field.label, encoding='utf-8'), res.content)
         self.assertIn(bytes(self.article.title, encoding='utf-8'), res.content)
 
         url = form.get_full_url()

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -171,7 +171,15 @@ class SkipLogicPaginator(Paginator):
             top_index = index + self.per_page
             top = self.page_breaks[top_index]
 
-        return self._get_page(self.object_list[bottom:top], index + 1, self)
+        if number != 1:
+            return self._get_page(self.object_list[bottom:top], number, self)
+
+        object_list = [
+            i for i in self.object_list
+            if i.field_type == 'hidden'
+        ]
+        object_list += self.object_list[bottom:top]
+        return self._get_page(object_list, number, self)
 
 
 class SkipLogicPage(Page):

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -29,8 +29,8 @@ class SkipLogicPaginator(Paginator):
 
         self.page_breaks = [
             i + 1 for i, field in enumerate(self.object_list)
-            if (field.has_skipping or field.page_break)
-            and (field.pk and field.field_type != 'hidden')
+            if (field.has_skipping or field.page_break) and
+               (field.pk and field.field_type != 'hidden')
         ]
 
         num_questions = len([

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -24,15 +24,18 @@ class SkipLogicPaginator(Paginator):
         # be sure to exclude hidden article_page field
         self.question_labels = [
             question.clean_name for question in self.object_list
-            if question.pk
+            if question.pk and question.field_type != 'hidden'
         ]
 
         self.page_breaks = [
             i + 1 for i, field in enumerate(self.object_list)
-            if (field.has_skipping or field.page_break) and field.pk
+            if (field.has_skipping or field.page_break)
+            and (field.pk and field.field_type != 'hidden')
         ]
 
-        num_questions = len([i for i in self.object_list if i.pk])
+        num_questions = len([
+            i for i in self.object_list
+            if i.pk and i.field_type != 'hidden'])
 
         if self.page_breaks:
             # Always have a break at start to create first page

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -21,16 +21,18 @@ class SkipLogicPaginator(Paginator):
 
         super(SkipLogicPaginator, self).__init__(object_list, per_page=1)
 
+        # be sure to exclude hidden article_page field
         self.question_labels = [
             question.clean_name for question in self.object_list
+            if question.pk
         ]
 
         self.page_breaks = [
             i + 1 for i, field in enumerate(self.object_list)
-            if field.has_skipping or field.page_break
+            if (field.has_skipping or field.page_break) and field.pk
         ]
 
-        num_questions = self.object_list.count()
+        num_questions = len([i for i in self.object_list if i.pk])
 
         if self.page_breaks:
             # Always have a break at start to create first page


### PR DESCRIPTION
Add `article_page` form field for `MoloFormSubmissions`, currently the submission don't save this value. 
Render form `hidden` fields in the first page of a multi-step form, currently the hidden fields are rendered on its own page which does not make any sense since they are hidden.
