### PR TITLE
Fix article page forms in api

### DIFF
--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -883,4 +883,4 @@ class ArticlePageForms(Orderable):
         help_text=_('Survey')
     )
     panels = [PageChooserPanel('form', 'forms.MoloFormPage')]
-    api_fields = ['forms']
+    api_fields = ['form']

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -10,7 +10,6 @@ from molo.core.models import (Languages, Main, SiteLanguageRelation,
 from molo.core.tests.base import MoloTestCaseMixin
 from molo.forms.templatetags.molo_forms_tags import url_to_anchor
 from molo.forms.models import (
-    ArticlePageForms,
     MoloFormField,
     MoloFormPage,
     FormsIndexPage,


### PR DESCRIPTION
This fixes the error raised on the article page api when a form is attached to the article.