### PR TITLE
fix forms_list_linked_to_pages template tag to only pull page article…

### DIFF
--- a/molo/forms/templatetags/molo_forms_tags.py
+++ b/molo/forms/templatetags/molo_forms_tags.py
@@ -163,21 +163,16 @@ def forms_list_for_pages(context, pk=None, page=None):
 
 @register.inclusion_tag('forms/forms_list.html', takes_context=True)
 def forms_list_linked_to_pages(context, article):
-    locale_code = context.get('locale_code')
+    _context = copy(context)
+    locale_code = _context.get('locale_code')
 
     queryset = article.forms.all()\
         .values_list('form', flat=True)
-
     forms = MoloFormPage.objects\
         .filter(pk__in=queryset)
 
-    if context.get('forms'):
-        forms = context['forms'] \
-            + get_pages(context, forms, locale_code)
-    else:
-        forms = get_pages(context, forms, locale_code)
-
-    context.update({'forms': forms})
+    forms = get_pages(_context, forms, locale_code)
+    _context['forms'] = forms
     return add_form_objects_to_forms(context)
 
 

--- a/molo/forms/tests/test_templatetags.py
+++ b/molo/forms/tests/test_templatetags.py
@@ -344,6 +344,10 @@ class FormListTest(TestCase, MoloTestCaseMixin):
         self.assertEqual(len(res['forms']), 1)
         self.assertEqual(res['forms'][0]['molo_form_page'], survey2)
 
+        res = forms_list_linked_to_pages(context, article)
+        self.assertEqual(len(res['forms']), 1)
+        self.assertEqual(res['forms'][0]['molo_form_page'], survey)
+
     def test_forms_list_linked_to_sub_pages(self):
         """
         Create a sub page with a linked molo form

--- a/molo/forms/tests/test_templatetags.py
+++ b/molo/forms/tests/test_templatetags.py
@@ -320,11 +320,29 @@ class FormListTest(TestCase, MoloTestCaseMixin):
         })
         survey = self.direct_molo_form_page
         article = self.mk_article(self.main)
+
         article_page_form = ArticlePageForms(form=survey, page=article)
         article.forms.add(article_page_form)
         res = forms_list_linked_to_pages(context, article)
         self.assertEqual(len(res['forms']), 1)
         self.assertEqual(res['forms'][0]['molo_form_page'], survey)
+
+        sub_section = self.mk_sections(article, count=1)[0]
+        sub_article = self.mk_article(sub_section)
+
+        survey2, survey2_form_field = (
+            self.create_molo_form_page(
+                parent=self.forms_index,
+                title="direct form title",
+                slug="direct_form_title",
+                display_form_directly=True,
+            ))
+
+        article_page_form = ArticlePageForms(form=survey2, page=sub_article)
+        sub_article.forms.add(article_page_form)
+        res = forms_list_linked_to_pages(context, sub_article)
+        self.assertEqual(len(res['forms']), 1)
+        self.assertEqual(res['forms'][0]['molo_form_page'], survey2)
 
     def test_forms_list_linked_to_sub_pages(self):
         """


### PR DESCRIPTION
fix forms_list_linked_to_pages template tag to only pull page articles, disregard those of parent