### PR TITLE
Skip to question pagination issue

### DIFF
--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -400,7 +400,7 @@ class MoloFormPage(
                 form_data.update(prev_form.cleaned_data)
                 self.save_data(request, form_data)
 
-                if prev_step.has_next():
+                if prev_step.has_next() and len(prev_step.object_list) > 0:
                     # Create a new form for a following step, if the following
                     # step is present
                     form_class = self.get_form_class_for_step(step)

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1002,7 +1002,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             label='Your favourite animal',
             field_type='singleline',
             required=True,
-            page_break=True
+            page_break=False
         )
 
         self.another_molo_form_field = (
@@ -1124,6 +1124,8 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         )
 
     def test_skip_logic_to_another_question(self):
+        self.molo_form_field.page_break = True
+        self.molo_form_field.save()
         response = self.client.get(self.molo_form_page.url)
 
         self.assertFormAndQuestions(
@@ -1162,7 +1164,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         self.skip_logic_form_field.field_type = 'checkbox'
         self.skip_logic_form_field.skip_logic = skip_logic_data(
             ['', ''],
-            self.choices[:2],
+            self.choices[:2],  # next, end
         )
         self.skip_logic_form_field.save()
 
@@ -1203,7 +1205,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         self.skip_logic_form_field.field_type = 'checkbox'
         self.skip_logic_form_field.skip_logic = skip_logic_data(
             ['', ''],
-            self.choices[:2],
+            self.choices[:2],  # next, end
         )
         self.skip_logic_form_field.save()
 

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -887,10 +887,12 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
         results = self.client.get(success_url + '?format=json')
         self.assertEqual(results.status_code, 200)
         self.assertEqual(
-            json.loads('{"a, b or c?": {"a": 100}, "article_page": {"%d": 100}}'
-                       % self.article.pk),
+            json.loads(
+                '{"a, b or c?": {"a": 100}, "article_page": {"%d": 100}}'
+                % self.article.pk
+            ),
             results.json()
-            )
+        )
 
 
 class TestDeleteButtonRemoved(TestCase, MoloTestCaseMixin):

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -876,9 +876,9 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
         results = self.client.get(success_url + '?format=json')
         self.assertEqual(results.status_code, 200)
         self.assertEqual(
-            b'{"a, b or c?": {"a": 1}, "article_page": {"%d": 1}}'
-            % self.article.pk,
-            results.content
+            json.loads('{"a, b or c?": {"a": 1}, "article_page": {"%d": 1}}'
+                       % self.article.pk),
+            results.json()
         )
 
         form.show_results_as_percentage = True
@@ -887,10 +887,10 @@ class TestFormViews(TestCase, MoloTestCaseMixin):
         results = self.client.get(success_url + '?format=json')
         self.assertEqual(results.status_code, 200)
         self.assertEqual(
-            b'{"a, b or c?": {"a": 100}, "article_page": {"%d": 100}}'
-            % self.article.pk,
-            results.content
-        )
+            json.loads('{"a, b or c?": {"a": 100}, "article_page": {"%d": 100}}'
+                       % self.article.pk),
+            results.json()
+            )
 
 
 class TestDeleteButtonRemoved(TestCase, MoloTestCaseMixin):

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -973,16 +973,17 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
 
         self.last_molo_form_field = MoloFormField.objects.create(
             page=self.molo_form_page,
-            sort_order=3,
+            sort_order=2,
             label='Your favourite actor',
             field_type='singleline',
-            required=True
+            required=True,
+            page_break=True
         )
 
         self.choices = ['next', 'end', 'form', 'question']
         self.skip_logic_form_field = MoloFormField.objects.create(
             page=self.molo_form_page,
-            sort_order=1,
+            sort_order=0,
             label='Where should we go',
             field_type='dropdown',
             skip_logic=skip_logic_data(
@@ -991,21 +992,23 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
                 form=self.another_molo_form_page,
                 question=self.last_molo_form_field,
             ),
-            required=True
+            required=True,
+            page_break=True
         )
 
         self.molo_form_field = MoloFormField.objects.create(
             page=self.molo_form_page,
-            sort_order=2,
+            sort_order=1,
             label='Your favourite animal',
             field_type='singleline',
-            required=True
+            required=True,
+            page_break=True
         )
 
         self.another_molo_form_field = (
             MoloFormField.objects.create(
                 page=self.another_molo_form_page,
-                sort_order=1,
+                sort_order=0,
                 label='Your favourite actress',
                 field_type='singleline',
                 required=True
@@ -1028,7 +1031,6 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         self.assertContains(response, form.title)
         self.assertContains(response, form.introduction)
         for question in questions:
-            self.assertContains(response, question.label)
             self.assertContains(response, question.label)
 
     def test_skip_logic_next_question(self):
@@ -1140,12 +1142,21 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             self.skip_logic_form_field.clean_name: self.choices[3],
         }, follow=True)
 
-        # Should end the form and progress to the new form
+        self.assertNotContains(response, self.skip_logic_form_field.label)
+        self.assertNotContains(response, self.molo_form_field.label)
+
+        # Should show the last question
         self.assertFormAndQuestions(
             response,
             self.molo_form_page,
             [self.last_molo_form_field],
         )
+
+        response = self.client.post(self.molo_form_page.url + '?p=3', {
+            self.last_molo_form_field.clean_name: "frank",
+        }, follow=True)
+
+        self.assertContains(response, self.molo_form_page.thank_you_text)
 
     def test_skip_logic_checkbox_with_data(self):
         self.skip_logic_form_field.field_type = 'checkbox'

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -35,9 +35,9 @@ class SkipLogicPaginator(Paginator):
                     answer = self.previous_answers[field.clean_name]
                     if field.is_next_action(answer, SkipState.QUESTION):
                         continue
-                self.page_breaks.append(i+1)
+                self.page_breaks.append(i + 1)
             elif field.page_break:
-                self.page_breaks.append(i+1)
+                self.page_breaks.append(i + 1)
 
         num_questions = len([
             i for i in self.object_list

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -189,9 +189,17 @@ class SkipLogicPage(Page):
     def possibly_has_next(self):
         return super(SkipLogicPage, self).has_next()
 
+    def get_last_non_empty_page(self, page):
+        # Recursively find the last page that had a question and return that
+        if len(page.object_list) == 0:
+            return self.get_last_non_empty_page(
+                self.paginator.page(page.previous_page_number()))
+        return page
+
     @cached_property
     def last_question(self):
-        return self.object_list[-1]
+        page = self.get_last_non_empty_page(self)
+        return page.object_list[-1]
 
     @cached_property
     def last_response(self):


### PR DESCRIPTION
Currently the paginator doesn't reduce the number of pages if a question with a page break has been skipped.
This means that some pages don't have any questions.
These changes mean that any already validated answers that resulted in a skip will reduce the number of pages in the paginator.
This fix is not perfect. It doesn't reduce the number of pages if the most recently submitted page skipped questions because the paginator is initialised before that page goes through validation.

Another side effect of this attempt to deal with pages that don't have any questions is that the last question does not get validated or submitted. This will be addressed before this goes live to all the sites.

This fix is urgent and therefore the tests are minimal. More tests will be added in the PR to fix the above side effect.