### PR TITLE
Fix skip logic

### DIFF
--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -382,11 +382,9 @@ class MoloFormPage(
             is_last_step = True
 
         if request.method == 'POST':
-            # The first step will be submitted with step_number == 2,
-            # so we need to get a from from previous step
-            # Edge case - submission of the last step
-            prev_step = step if is_last_step else paginator.page(
-                int(step_number) - 1)
+            # To validate the previous step we need to get it's form
+            # use the paginator to figure it out
+            prev_step = paginator.page(paginator.current_page)
 
             # Create a form only for submitted step
             prev_form_class = self.get_form_class_for_step(prev_step)
@@ -399,8 +397,7 @@ class MoloFormPage(
                 # If data for step is valid, update the session
                 form_data.update(prev_form.cleaned_data)
                 self.save_data(request, form_data)
-
-                if prev_step.has_next() and len(prev_step.object_list) > 0:
+                if prev_step.has_next() and paginator.current_page != paginator.num_pages:
                     # Create a new form for a following step, if the following
                     # step is present
                     form_class = self.get_form_class_for_step(step)

--- a/molo/forms/models.py
+++ b/molo/forms/models.py
@@ -370,7 +370,6 @@ class MoloFormPage(
             form_data,
         )
 
-        is_last_step = False
         step_number = request.GET.get('p', 1)
 
         try:
@@ -379,7 +378,6 @@ class MoloFormPage(
             step = paginator.page(1)
         except EmptyPage:
             step = paginator.page(paginator.num_pages)
-            is_last_step = True
 
         if request.method == 'POST':
             # To validate the previous step we need to get it's form
@@ -397,7 +395,8 @@ class MoloFormPage(
                 # If data for step is valid, update the session
                 form_data.update(prev_form.cleaned_data)
                 self.save_data(request, form_data)
-                if prev_step.has_next() and paginator.current_page != paginator.num_pages:
+                if (prev_step.has_next() and
+                        paginator.current_page != paginator.num_pages):
                     # Create a new form for a following step, if the following
                     # step is present
                     form_class = self.get_form_class_for_step(step)

--- a/molo/forms/tests/test_models.py
+++ b/molo/forms/tests/test_models.py
@@ -352,6 +352,7 @@ class TestPageBreakWithTwoQuestionsInOneStep(TestCase, MoloTestCaseMixin):
         })
         self.assertContains(response, field_2.label)
         self.assertContains(response, field_3.label)
+        self.assertContains(response, 'action="' + form.url + '?p=3"')
 
         response = self.client.post(form.url + '?p=3', {
             field_3.clean_name: 'because ;)',

--- a/molo/forms/tests/test_utils.py
+++ b/molo/forms/tests/test_utils.py
@@ -25,9 +25,9 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
             field_type='singleline',
             required=True
         )
-        self.fourth_field = MoloFormField.objects.create(
+        self.fifth_field = MoloFormField.objects.create(
             page=self.form,
-            sort_order=4,
+            sort_order=5,
             label='A random animal',
             field_type='singleline',
             required=True
@@ -41,7 +41,7 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
             skip_logic=skip_logic_data(
                 field_choices,
                 field_choices,
-                question=self.fourth_field,
+                question=self.fifth_field,
             ),
             required=True
         )
@@ -53,9 +53,17 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
             skip_logic=skip_logic_data(
                 field_choices,
                 field_choices,
-                question=self.fourth_field,
+                question=self.fifth_field,
             ),
             required=True
+        )
+        self.fourth_field = MoloFormField.objects.create(
+            page=self.form,
+            sort_order=4,
+            label='Your least favourite animal',
+            field_type='singleline',
+            required=True,
+            page_break=True
         )
         self.hidden_field = MoloFormField.objects.create(
             page=self.form,
@@ -68,10 +76,10 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         self.paginator = SkipLogicPaginator(self.form.get_form_fields())
 
     def test_correct_num_pages(self):
-        self.assertEqual(self.paginator.num_pages, 3)
+        self.assertEqual(self.paginator.num_pages, 4)
 
     def test_page_breaks_correct(self):
-        self.assertEqual(self.paginator.page_breaks, [0, 2, 3, 4])
+        self.assertEqual(self.paginator.page_breaks, [0, 2, 3, 4, 5])
 
     def test_first_page_correct(self):
         page = self.paginator.page(1)
@@ -89,9 +97,14 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         self.assertEqual(page.object_list, [self.third_field])
         self.assertTrue(page.has_next())
 
+    def test_third_page_correct(self):
+        third_page = self.paginator.page(3)
+        self.assertEqual(third_page.object_list, [self.fourth_field])
+        self.assertTrue(third_page.has_next())
+
     def test_last_page_correct(self):
-        last_page = self.paginator.page(3)
-        self.assertEqual(last_page.object_list, [self.fourth_field])
+        last_page = self.paginator.page(4)
+        self.assertEqual(last_page.object_list, [self.fifth_field])
         self.assertFalse(last_page.has_next())
 
     def test_is_end_if_skip_logic(self):
@@ -109,9 +122,10 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         )
         page = paginator.page(1)
         next_page_number = page.next_page_number()
-        self.assertEqual(next_page_number, 3)
+        self.assertEqual(next_page_number, 4)
         second_page = paginator.page(next_page_number)
-        self.assertEqual(second_page.object_list, [self.fourth_field])
+        self.assertEqual(second_page.object_list, [self.fifth_field])
+        self.assertFalse(second_page.has_next())
 
     def test_first_question_skip_to_next(self):
         paginator = SkipLogicPaginator(
@@ -134,7 +148,7 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         )
         page = paginator.page(1)
         next_page_number = page.next_page_number()
-        self.assertEqual(next_page_number, 3)
+        self.assertEqual(next_page_number, 4)
         second_page = paginator.page(next_page_number)
         previous_page_number = second_page.previous_page_number()
         self.assertEqual(previous_page_number, 1)
@@ -156,8 +170,8 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         )
         self.assertEqual(paginator.previous_page, 1)
         self.assertEqual(paginator.last_question_index, 1)
-        self.assertEqual(paginator.next_page, 3)
-        self.assertEqual(paginator.next_question_index, 3)
+        self.assertEqual(paginator.next_page, 4)
+        self.assertEqual(paginator.next_question_index, 4)
 
     def test_no_data_index(self):
         paginator = SkipLogicPaginator(self.form.get_form_fields())
@@ -185,6 +199,7 @@ class TestSkipLogicPaginator(TestCase, MoloTestCaseMixin):
         self.first_field.delete()
         self.third_field.delete()
         self.fourth_field.delete()
+        self.fifth_field.delete()
         paginator = SkipLogicPaginator(self.form.get_form_fields())
         self.assertEqual(paginator.num_pages, 1)
 

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1125,7 +1125,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             [self.another_molo_form_field],
         )
 
-    def test_skip_logic_to_another_question_without_skipped_page_breaks(self):
+    def test_skip_logic_to_question_without_skipped_page_breaks(self):
         response = self.client.get(self.molo_form_page.url)
 
         self.assertFormAndQuestions(
@@ -1166,7 +1166,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             "your-favourite-animal": "NA (Skipped)",
             "your-favourite-actor": "frank"})
 
-    def test_skip_logic_to_another_question_with_one_skipped_page_break(self):
+    def test_skip_logic_to_question_with_one_skipped_page_break(self):
         self.molo_form_field.page_break = True
         self.molo_form_field.save()
 
@@ -1210,7 +1210,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             "your-favourite-animal": "NA (Skipped)",
             "your-favourite-actor": "frank"})
 
-    def test_skip_logic_to_another_question_with_multiple_skipped_page_breaks(self):
+    def test_skip_logic_to_question_with_multiple_skipped_page_breaks(self):
         self.molo_form_field.page_break = True
         self.molo_form_field.save()
         # add another form field to skip over
@@ -1223,7 +1223,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             page_break=True
         )
         # Move the last question down and make sure the skip logic points to it
-        self.last_molo_form_field.sort_order=3
+        self.last_molo_form_field.sort_order = 3
         self.last_molo_form_field.save()
         self.skip_logic_form_field.skip_logic = skip_logic_data(
             self.choices,
@@ -1275,9 +1275,9 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             "extra-question": "NA (Skipped)",
             "your-favourite-actor": "frank"})
 
-    def test_skip_logic_doesnt_repeat_pages_if_earlier_pages_were_skipped(self):
-        # The previous method of calculating page breaks led to later pages being
-        # displayed multiple times
+    def test_skip_logic_doesnt_repeat_pages_if_prev_pages_skipped(self):
+        # The previous method of calculating page breaks led to later
+        # pages being displayed multiple times
 
         self.molo_form_field.page_break = True
         self.molo_form_field.save()

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1125,9 +1125,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
             [self.another_molo_form_field],
         )
 
-    def test_skip_logic_to_another_question(self):
-        self.molo_form_field.page_break = True
-        self.molo_form_field.save()
+    def test_skip_logic_to_another_question_without_skipped_page_breaks(self):
         response = self.client.get(self.molo_form_page.url)
 
         self.assertFormAndQuestions(
@@ -1161,6 +1159,119 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         }, follow=True)
 
         self.assertContains(response, self.molo_form_page.thank_you_text)
+        subs = self.molo_form_page.get_submission_class().objects.all()
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(json.loads(subs[0].form_data), {
+            "where-should-we-go": "question",
+            "your-favourite-animal": "NA (Skipped)",
+            "your-favourite-actor": "frank"})
+
+    def test_skip_logic_to_another_question_with_one_skipped_page_break(self):
+        self.molo_form_field.page_break = True
+        self.molo_form_field.save()
+
+        response = self.client.get(self.molo_form_page.url)
+
+        self.assertFormAndQuestions(
+            response,
+            self.molo_form_page,
+            [self.skip_logic_form_field]
+        )
+        self.assertNotContains(
+            response,
+            self.last_molo_form_field.label,
+        )
+        self.assertNotContains(response, self.molo_form_field.label)
+        self.assertContains(response, 'Next Question')
+
+        response = self.client.post(self.molo_form_page.url + '?p=2', {
+            self.skip_logic_form_field.clean_name: self.choices[3],
+        }, follow=True)
+
+        self.assertNotContains(response, self.skip_logic_form_field.label)
+        self.assertNotContains(response, self.molo_form_field.label)
+
+        # Should show the last question
+        self.assertFormAndQuestions(
+            response,
+            self.molo_form_page,
+            [self.last_molo_form_field],
+        )
+
+        response = self.client.post(self.molo_form_page.url + '?p=3', {
+            self.last_molo_form_field.clean_name: "frank",
+        }, follow=True)
+
+        self.assertContains(response, self.molo_form_page.thank_you_text)
+        subs = self.molo_form_page.get_submission_class().objects.all()
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(json.loads(subs[0].form_data), {
+            "where-should-we-go": "question",
+            "your-favourite-animal": "NA (Skipped)",
+            "your-favourite-actor": "frank"})
+
+    def test_skip_logic_to_another_question_with_multiple_skipped_page_breaks(self):
+        self.molo_form_field.page_break = True
+        self.molo_form_field.save()
+        # add another form field to skip over
+        self.extra_form_field = MoloFormField.objects.create(
+            page=self.molo_form_page,
+            sort_order=2,
+            label='extra question',
+            field_type='singleline',
+            required=True,
+            page_break=True
+        )
+        # Move the last question down and make sure the skip logic points to it
+        self.last_molo_form_field.sort_order=3
+        self.last_molo_form_field.save()
+        self.skip_logic_form_field.skip_logic = skip_logic_data(
+            self.choices,
+            self.choices,
+            form=self.another_molo_form_page,
+            question=self.last_molo_form_field,
+        )
+        self.skip_logic_form_field.save()
+
+        response = self.client.get(self.molo_form_page.url)
+
+        self.assertFormAndQuestions(
+            response,
+            self.molo_form_page,
+            [self.skip_logic_form_field]
+        )
+        self.assertNotContains(
+            response,
+            self.last_molo_form_field.label,
+        )
+        self.assertNotContains(response, self.molo_form_field.label)
+        self.assertContains(response, 'Next Question')
+
+        response = self.client.post(self.molo_form_page.url + '?p=2', {
+            self.skip_logic_form_field.clean_name: self.choices[3],
+        }, follow=True)
+
+        self.assertNotContains(response, self.skip_logic_form_field.label)
+        self.assertNotContains(response, self.molo_form_field.label)
+
+        # Should show the last question
+        self.assertFormAndQuestions(
+            response,
+            self.molo_form_page,
+            [self.last_molo_form_field],
+        )
+
+        response = self.client.post(self.molo_form_page.url + '?p=3', {
+            self.last_molo_form_field.clean_name: "frank",
+        }, follow=True)
+
+        self.assertContains(response, self.molo_form_page.thank_you_text)
+        subs = self.molo_form_page.get_submission_class().objects.all()
+        self.assertEqual(len(subs), 1)
+        self.assertEqual(json.loads(subs[0].form_data), {
+            "where-should-we-go": "question",
+            "your-favourite-animal": "NA (Skipped)",
+            "your-favourite-actor": "frank"})
 
     def test_skip_logic_checkbox_with_data(self):
         self.skip_logic_form_field.field_type = 'checkbox'

--- a/molo/forms/tests/test_views.py
+++ b/molo/forms/tests/test_views.py
@@ -1253,6 +1253,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
 
         self.assertNotContains(response, self.skip_logic_form_field.label)
         self.assertNotContains(response, self.molo_form_field.label)
+        self.assertNotContains(response, self.extra_form_field.label)
 
         # Should show the last question
         self.assertFormAndQuestions(
@@ -1271,6 +1272,7 @@ class TestSkipLogicFormView(TestCase, MoloTestCaseMixin):
         self.assertEqual(json.loads(subs[0].form_data), {
             "where-should-we-go": "question",
             "your-favourite-animal": "NA (Skipped)",
+            "extra-question": "NA (Skipped)",
             "your-favourite-actor": "frank"})
 
     def test_skip_logic_checkbox_with_data(self):

--- a/molo/forms/utils.py
+++ b/molo/forms/utils.py
@@ -26,7 +26,7 @@ class SkipLogicPaginator(Paginator):
             question.clean_name for question in self.object_list
             if question.pk and question.field_type != 'hidden'
         ]
-        
+
         self.page_breaks = []
         i = 0
         while i < len(self.object_list):
@@ -43,16 +43,17 @@ class SkipLogicPaginator(Paginator):
                     # skipped questions
                     # just add one before the question we're skipping TO
                     answer = self.previous_answers[field.clean_name]
-                    if field.is_next_action(answer,SkipState.QUESTION):
-                        next_question = field.skip_logic[field.choice_index(answer)].value['question']
+                    if field.is_next_action(answer, SkipState.QUESTION):
+                        next_question = field.skip_logic[
+                            field.choice_index(answer)].value['question']
                         i = next_question - 1
 
             elif field.page_break:
                 self.page_breaks.append(i)
 
         num_questions = len([
-            i for i in self.object_list
-            if i.pk and i.field_type != 'hidden'])
+            j for j in self.object_list
+            if j.pk and j.field_type != 'hidden'])
 
         if self.page_breaks:
             # Always have a break at start to create first page


### PR DESCRIPTION
A PR to fix all the things I could with skip logic (previous PR for reference https://github.com/praekeltfoundation/molo.forms/pull/34).
a) the changes in the previous PR meant that the last question in a survey with skipped questions wouldn't get saved. These changes to models.py fixes that.
b) the way that page breaks were calculated before the previous PR meant that pages after skipped questions behaved strangely, some were repeated while others had validation run on them before the user had a chance to see them. This PR builds on the previous one to ensure that page breaks for any skipped questions are discounted.
c) adds more tests for the work done in the previous PR